### PR TITLE
Update project to use PackageReference

### DIFF
--- a/cTakesXMLParser/cTakesXMLParser.csproj
+++ b/cTakesXMLParser/cTakesXMLParser.csproj
@@ -36,22 +36,9 @@
     <ApplicationIcon>Capsrojiblau.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ExcelDataReader, Version=3.1.0.0, Culture=neutral, PublicKeyToken=93517dbe6a4012fa, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDataReader.3.1.0\lib\net45\ExcelDataReader.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="ExcelDataReader.DataSet, Version=3.1.0.0, Culture=neutral, PublicKeyToken=93517dbe6a4012fa, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDataReader.DataSet.3.1.0\lib\net45\ExcelDataReader.DataSet.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="itextsharp, Version=5.5.12.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
-      <HintPath>..\packages\iTextSharp.5.5.12\lib\itextsharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office.Interop.Word, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.Office.Interop.Word.15.0.4797.1003\lib\net20\Microsoft.Office.Interop.Word.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <PackageReference Include="ExcelDataReader.DataSet" Version="3.1.0" />
+    <PackageReference Include="iTextSharp" Version="5.5.12" />
+    <PackageReference Include="Microsoft.Office.Interop.Word" Version="15.0.4797.1003" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -75,7 +62,6 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Capsrojiblau.ico" />

--- a/cTakesXMLParser/packages.config
+++ b/cTakesXMLParser/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="ExcelDataReader" version="3.1.0" targetFramework="net461" />
-  <package id="ExcelDataReader.DataSet" version="3.1.0" targetFramework="net461" />
-  <package id="iTextSharp" version="5.5.12" targetFramework="net461" />
-  <package id="Microsoft.Office.Interop.Word" version="15.0.4797.1003" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
since VS2017 does not restore packages if by default RestorePackage reference style configured in VS settings
Also that allow move project to SDK-based format with less work